### PR TITLE
lscsv removes escape chars from spaces. (closes #20)

### DIFF
--- a/lscsv/lscsv.sh
+++ b/lscsv/lscsv.sh
@@ -50,7 +50,7 @@ for line in sys.stdin:
 	line = line.strip('\n')
 	r = line.split(None, 10)
 	fn = r.pop()
-	fn = (','.join(r) + ',\"' + fn.replace('\"', '\"\"') + '\"')
+	fn = (','.join(r) + ',\"' + fn.replace('\"', '\"\"').replace('\\ ', ' ') + '\"')
 	fn = fn.split(',').pop()
 	csv.append(fn)
 


### PR DESCRIPTION
Fixes issue #20 by replacing "\ " with a single space.